### PR TITLE
[FEAT] (멘토) 과제 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/spring/hi_hello_spring/evaluation/query/controller/TaskQueryController.java
+++ b/src/main/java/spring/hi_hello_spring/evaluation/query/controller/TaskQueryController.java
@@ -8,8 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import spring.hi_hello_spring.common.response.ApiResponse;
 import spring.hi_hello_spring.common.response.ResponseUtil;
-import spring.hi_hello_spring.employee.query.dto.MenteeAllQueryDTO;
-import spring.hi_hello_spring.evaluation.query.dto.TaskHrAllListQueryDTO;
+import spring.hi_hello_spring.evaluation.query.dto.TaskAllListQueryDTO;
 import spring.hi_hello_spring.evaluation.query.service.TaskQueryService;
 
 import java.util.List;
@@ -23,10 +22,18 @@ public class TaskQueryController {
     private final TaskQueryService taskQueryService;
 
     @GetMapping("/hr/task")
-    @Operation(summary = "과제 리스트 조회", description = "담당자가 조회하는 과제 리스트 조회 기능입니다.")
+    @Operation(summary = "담당자 과제 리스트 조회", description = "담당자가 조회하는 과제 리스트 조회 기능입니다.")
     public ApiResponse<?> getAllTaskList() {
 
-        List<TaskHrAllListQueryDTO> taskHrAllListQueryDTO = taskQueryService.getHrAllTaskList();
-        return ResponseUtil.successResponse("멘티 전체 조회가 성공적으로 조회되었습니다.", taskHrAllListQueryDTO).getBody();
+        List<TaskAllListQueryDTO> taskAllListQueryDTO = taskQueryService.getHrAllTaskList();
+        return ResponseUtil.successResponse("멘티 전체 조회가 성공적으로 조회되었습니다.", taskAllListQueryDTO).getBody();
+    }
+
+    @GetMapping("/mentor/task")
+    @Operation(summary = "멘토 과제 리스트 조회", description = "멘토가 조회하는 과제 리스트 조회 기능입니다.")
+    public ApiResponse<?> getAllMentorTaskList() {
+
+        List<TaskAllListQueryDTO> taskAllListQueryDTO = taskQueryService.getMentorAllTaskList();
+        return ResponseUtil.successResponse("멘티 전체 조회가 성공적으로 조회되었습니다.", taskAllListQueryDTO).getBody();
     }
 }

--- a/src/main/java/spring/hi_hello_spring/evaluation/query/dto/TaskAllListQueryDTO.java
+++ b/src/main/java/spring/hi_hello_spring/evaluation/query/dto/TaskAllListQueryDTO.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 @Setter
 @ToString
 @RequiredArgsConstructor
-public class TaskHrAllListQueryDTO {
+public class TaskAllListQueryDTO {
 
     private Long taskSeq;
     private Long departmentSeq;

--- a/src/main/java/spring/hi_hello_spring/evaluation/query/mapper/TaskQueryMapper.java
+++ b/src/main/java/spring/hi_hello_spring/evaluation/query/mapper/TaskQueryMapper.java
@@ -1,13 +1,15 @@
 package spring.hi_hello_spring.evaluation.query.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
-import spring.hi_hello_spring.evaluation.query.dto.TaskHrAllListQueryDTO;
+import spring.hi_hello_spring.evaluation.query.dto.TaskAllListQueryDTO;
 
 import java.util.List;
 
 @Mapper
 public interface TaskQueryMapper {
 
-    List<TaskHrAllListQueryDTO> findHrAllTask();
+    List<TaskAllListQueryDTO> findHrAllTask();
 
+
+    List<TaskAllListQueryDTO> findMentorAllTask(Long employeeSeq);
 }

--- a/src/main/java/spring/hi_hello_spring/evaluation/query/service/TaskQueryService.java
+++ b/src/main/java/spring/hi_hello_spring/evaluation/query/service/TaskQueryService.java
@@ -2,7 +2,7 @@ package spring.hi_hello_spring.evaluation.query.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import spring.hi_hello_spring.evaluation.query.dto.TaskHrAllListQueryDTO;
+import spring.hi_hello_spring.evaluation.query.dto.TaskAllListQueryDTO;
 import spring.hi_hello_spring.evaluation.query.mapper.TaskQueryMapper;
 
 import java.util.List;
@@ -12,8 +12,15 @@ import java.util.List;
 public class TaskQueryService {
     private final TaskQueryMapper taskQueryMapper;
 
-    public List<TaskHrAllListQueryDTO> getHrAllTaskList() {
+    public List<TaskAllListQueryDTO> getHrAllTaskList() {
 
         return taskQueryMapper.findHrAllTask();
+    }
+
+    public List<TaskAllListQueryDTO> getMentorAllTaskList() {
+
+        Long employeeSeq = 3L; // 로그인 기능 완성되면 코드 수정하겠습니다.
+
+        return taskQueryMapper.findMentorAllTask(employeeSeq);
     }
 }

--- a/src/main/resources/mapper/evaluation/task/TaskMapper.xml
+++ b/src/main/resources/mapper/evaluation/task/TaskMapper.xml
@@ -4,7 +4,7 @@
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="spring.hi_hello_spring.evaluation.query.mapper.TaskQueryMapper">
 
-    <select id="findHrAllTask" resultType="TaskHrAllListQueryDTO">
+    <select id="findHrAllTask" resultType="TaskAllListQueryDTO">
         SELECT
         a.task_seq,
         a.department_seq,
@@ -39,5 +39,47 @@
         FROM onboarding_status os
         JOIN template t ON os.template_seq = t.template_seq
         ) t ON e.employee_seq = t.employee_seq
+    </select>
+
+    <select id="findMentorAllTask" parameterType="java.lang.Long" resultType="TaskAllListQueryDTO">
+        SELECT
+        a.task_seq,
+        a.department_seq,
+        d.department_name,
+        e.employee_seq,
+        CASE
+        WHEN a.task_type = 'PERSONER' THEN e.employee_name
+        WHEN a.task_type = 'GROUP' THEN CAST(rt.group_rank AS CHAR)
+        END AS display_name,
+        a.task_content,
+        t.template_seq,
+        t.template_task_round
+        FROM task a
+        JOIN department d ON a.department_seq = d.department_seq
+        JOIN employee e ON d.department_seq = e.department_seq
+        LEFT JOIN (
+        SELECT
+        tg.task_seq,
+        tg.task_group_seq,
+        ROW_NUMBER() OVER (
+        PARTITION BY tg.task_seq
+        ORDER BY tg.task_group_seq
+        ) AS group_rank
+        FROM task_group tg
+        WHERE tg.task_group_active_status = 1
+        ) rt ON a.task_seq = rt.task_seq
+        LEFT JOIN (
+        SELECT
+        os.employee_seq,
+        t.template_seq,
+        t.template_task_round
+        FROM onboarding_status os
+        JOIN template t ON os.template_seq = t.template_seq
+        ) t ON e.employee_seq = t.employee_seq
+        WHERE a.department_seq = (
+        SELECT department_seq
+        FROM employee
+        WHERE employee_seq = #{employeeSeq}
+        )
     </select>
 </mapper>


### PR DESCRIPTION
## 📖개요

(멘토) 과제 리스트 조회 기능 구현 (멘토의 departmentSeq와 같은 Seq를 가진 리스트만 조회되게 구현)
employeeSeq 로그인 구현되면 시큐리티 Seq로 바꾸겠습니다.
<img width="941" alt="스크린샷 2024-12-04 오후 8 11 28" src="https://github.com/user-attachments/assets/08564893-c1d7-460b-abab-20009c3960ef">

## 연결된 issue

<br>
close #115 
<br>
<br>

## 💻작업사항
- TaskQueryService 코드 추가
- TaskQueryMapper 코드 추가
- TaskQueryController 코드 추가
- TaskMapper.xml 코드 추가
- TaskAllListQueryDTO 코드 추가
<br>



## 💡작성한 이슈 외에 작업한 사항
-