### PR TITLE
[REFACTOR] 멘토가 계획서 작성 시 해당 부서 팀장에게 알림 전송하도록 리팩토링

### DIFF
--- a/src/main/java/spring/hi_hello_spring/employee/command/domain/repository/EmployeeRepository.java
+++ b/src/main/java/spring/hi_hello_spring/employee/command/domain/repository/EmployeeRepository.java
@@ -14,4 +14,6 @@ public interface EmployeeRepository{
     Employee save(Employee newEmployee);
 
     void deleteById(Long employeeSeq);
+
+    Optional<Employee> findByDepartmentSeqAndPositionSeq(Long departmentSeq, Long positionSeq);
 }

--- a/src/main/java/spring/hi_hello_spring/mentoring/command/application/service/MentoringPlanService.java
+++ b/src/main/java/spring/hi_hello_spring/mentoring/command/application/service/MentoringPlanService.java
@@ -1,5 +1,6 @@
 package spring.hi_hello_spring.mentoring.command.application.service;
 
+import com.sun.jna.platform.win32.WinDef;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
@@ -46,6 +47,15 @@ public class MentoringPlanService {
                 .fileUrl(uploadFile)
                 .build();
         fileRepository.save(file);
+
+        Long senderSeq = mentoringPlanRequestDTO.getEmployeeSeq();
+        Employee sender = employeeRepository.findByEmployeeSeq(senderSeq)
+                .orElseThrow(() -> new CustomException(ErrorCodeType.USER_NOT_FOUND));
+
+        Employee receiver = employeeRepository.findByDepartmentSeqAndPositionSeq(sender.getDepartmentSeq(), 1L)
+                .orElseThrow(() -> new CustomException(ErrorCodeType.USER_NOT_FOUND));
+
+        notifyService.send(sender, receiver, WRITTEN_PLANER_BY_MENTOR, "/mentoring/planning/" + savedPlanning.getPlanningSeq());
     }
 
     @Transactional

--- a/src/main/java/spring/hi_hello_spring/notify/command/domain/aggregate/entity/NotiType.java
+++ b/src/main/java/spring/hi_hello_spring/notify/command/domain/aggregate/entity/NotiType.java
@@ -15,7 +15,10 @@ public enum NotiType {
     ALLOW_PLANER_BY_LEADER("멘토링 계획서가 승인되었습니다."),
     REJECT_PLANER_BY_LEADER("멘토링 계획서가 반려되었습니다."),
 
-    WRITTEN_REPORT_BY_MENTEE("멘티가 보고서를 작성하였습니다.");
+    WRITTEN_REPORT_BY_MENTEE("멘티가 보고서를 작성하였습니다."),
+
+    CREATE_CHATTING_ROOM("멘토링 채팅방이 개설되었습니다."),
+    CREATE_GROUP_CHATTING_ROOM("그룹 과제 채팅방이 개설되었습니다."),
 
     ;
 


### PR DESCRIPTION
## 📖개요

멘토가 계획서 작성 시 해당 부서 팀장에게 알림 전송하도록 리팩토링

## 연결된 issue

<br>
close #457 
<br>
<br>

## 💻작업사항
- 계획서 등록 로직 리팩토링

![image](https://github.com/user-attachments/assets/aac11a20-b562-4a0f-bb16-023eebb22931)

<br>



## 💡작성한 이슈 외에 작업한 사항
-